### PR TITLE
Add Code Of Conduct file for GSSoC 2025 contribution

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Using welcoming and inclusive language  
+- Being respectful of differing viewpoints and experiences  
+- Gracefully accepting constructive criticism  
+- Focusing on what is best for the community  
+- Showing empathy towards other community members
+
+## Unacceptable Behavior
+
+Unacceptable behaviors include:
+
+- Harassment, intimidation, or discrimination in any form  
+- Trolling, insulting/derogatory comments, and personal or political attacks  
+- Public or private harassment  
+- Publishing others’ private information, such as physical or electronic addresses, without explicit permission  
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing this Code of Conduct. They have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct.
+
+## Reporting
+
+If you experience or witness any unacceptable behavior, please report it by opening a GitHub issue labeled **"code of conduct violation"** or by contacting the project maintainers via GitHub.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by anyone and will be reviewed and investigated by the project maintainers. Maintainers are obligated to maintain confidentiality with regard to the reporter of such incidents.  
+
+Maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent consequences as determined by the project’s governance.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.md


### PR DESCRIPTION
This pull request adds a CODE_OF_CONDUCT.md file to the CRM-Driven Internship Application Tracker project as part of my contribution for GirlScript Summer of Code 2025 (GSSoC’25).

The Code of Conduct outlines expected behavior to foster a welcoming, respectful, and inclusive community for all contributors. It helps maintain a positive environment and provides guidelines for reporting and handling unacceptable behavior.

This addition improves the project’s documentation and aligns with best practices in open-source community management.