### PR TITLE
Add auto-updating contributors tab to README.md using GitHub Actions (fixes #9)

### DIFF
--- a/.github/scripts/update_readme.py
+++ b/.github/scripts/update_readme.py
@@ -1,0 +1,95 @@
+import requests
+import re
+import os
+
+# GitHub API endpoint for contributors
+repo = "Varunshiyam/CRM-Driven-Internship-Application-Tracker"
+url = f"https://api.github.com/repos/{repo}/contributors"
+headers = {
+    "Authorization": f"token {os.getenv('GITHUB_TOKEN')}",
+    "Accept": "application/vnd.github.v3+json"
+}
+
+# Fetch contributors
+response = requests.get(url, headers=headers)
+response.raise_for_status()
+contributors = response.json()
+
+# Generate HTML for contributors tab
+contributor_html = ""
+for contributor in contributors:
+    contributor_html += f"""
+    <div style="display: inline-block; padding: 10px; text-align: center; min-width: 150px;">
+      <a href="{contributor['html_url']}" target="_blank" style="text-decoration: none; color: #333;">
+        <img src="{contributor['avatar_url']}" alt="{contributor['login']}" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 5px;">
+        <div style="font-size: 14px; font-weight: bold;">{contributor['login']}</div>
+        <div style="font-size: 12px; color: #666;">{contributor['contributions']} contribution{'s' if contributor['contributions'] != 1 else ''}</div>
+      </a>
+    </div>
+    """
+
+# Contributors section with CSS
+contributors_section = f"""
+## Contributors
+
+Below is an auto-scrolling tab showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
+
+<div id="contributor-tab" style="overflow-x: hidden; white-space: nowrap; width: 100%; padding: 10px 0; background-color: #f9f9f9; border-radius: 8px;">
+  <div id="contributor-list" style="display: inline-block; animation: scroll 20s linear infinite;">
+    <!-- Contributor items (original list) -->
+    {contributor_html}
+    <!-- Duplicated list for seamless infinite scroll -->
+    {contributor_html}
+  </div>
+</div>
+
+<style>
+@keyframes scroll {{
+  0% {{ transform: translateX(0); }}
+  100% {{ transform: translateX(-50%); }}
+}}
+
+#contributor-tab::-webkit-scrollbar {{
+  display: none; /* Hide scrollbar for cleaner look */
+}}
+
+#contributor-list:hover {{
+  animation-play-state: paused; /* Pause on hover */
+}}
+
+@media (max-width: 600px) {{
+  #contributor-list div {{
+    min-width: 120px; /* Smaller for mobile */
+  }}
+  #contributor-list img {{
+    width: 40px;
+    height: 40px;
+  }}
+  #contributor-list div div {{
+    font-size: 12px; /* Adjust font */
+  }}
+}}
+</style>
+"""
+
+# Read current README
+with open("README.md", "r", encoding="utf-8") as file:
+    content = file.read()
+
+# Replace or insert Contributors section
+if "## Contributors" in content:
+    new_content = re.sub(
+        r"## Contributors\n.*?(\n---\n## 🏁 Getting Started)",
+        f"{contributors_section}\\1",
+        content,
+        flags=re.DOTALL
+    )
+else:
+    new_content = content.replace(
+        "\n---\n## 🏁 Getting Started",
+        f"\n{contributors_section}\n---\n## 🏁 Getting Started"
+    )
+
+# Write updated README
+with open("README.md", "w", encoding="utf-8") as file:
+    file.write(new_content)

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,42 @@
+name: Update Contributors in README
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+  push:
+    branches:
+      - main
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  update-contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+
+      - name: Update README with contributors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python .github/scripts/update_readme.py
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add README.md
+          git commit -m "Update contributors list in README" || echo "No changes to commit"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 
 
+
 ---
 
 ### Key Directories
@@ -194,18 +195,18 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 ## Contributors
 
-These are our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
+Below is a single horizontal line showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
 
 <table style="overflow-x: auto; white-space: nowrap; width: 100%; padding: 12px 0; background: linear-gradient(to right, #f5f7fa, #e0e7ff); border-radius: 10px; border: 1px solid #d1d9e6; box-shadow: 0 2px 4px rgba(0,0,0,0.1); border-collapse: collapse; margin: 10px 0;">
   <tr>
-    <td style="display: inline-block; padding: 12px; text-align: center; min-width: 160px; vertical-align: middle; @media (max-width: 600px) { min-width: 120px; padding: 8px; }">
+    <td style="display: inline-block; padding: 12px; text-align: center; min-width: 180px; vertical-align: middle; @media (max-width: 600px) { min-width: 140px; padding: 8px; }">
       <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
         <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 6px; @media (max-width: 600px) { width: 40px; height: 40px; }">
         <div style="font-size: 15px; font-weight: bold; color: #2c3e50; @media (max-width: 600px) { font-size: 12px; }">Varunshiyam</div>
         <div style="font-size: 13px; color: #7f8c8d; @media (max-width: 600px) { font-size: 10px; }">31 contributions</div>
       </a>
     </td>
-    <td style="display: inline-block; padding: 12px; text-align: center; min-width: 160px; vertical-align: middle; @media (max-width: 600px) { min-width: 120px; padding: 8px; }">
+    <td style="display: inline-block; padding: 12px; text-align: center; min-width: 180px; vertical-align: middle; @media (max-width: 600px) { min-width: 140px; padding: 8px; }">
       <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
         <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 6px; @media (max-width: 600px) { width: 40px; height: 40px; }">
         <div style="font-size: 15px; font-weight: bold; color: #2c3e50; @media (max-width: 600px) { font-size: 12px; }">Meghana-2124</div>

--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 ## 📂 Project Structure
 
-
 ```
 .
 ├── .gitignore
@@ -173,6 +172,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 
 
+
 ---
 
 ### Key Directories
@@ -189,36 +189,36 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 Below is an auto-scrolling tab showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
 
-<div id="contributor-tab" style="overflow-x: hidden; white-space: nowrap; width: 100%; padding: 10px 0; background-color: #f9f9f9; border-radius: 8px;">
-  <div id="contributor-list" style="display: inline-block; animation: scroll 20s linear infinite;">
+<div id="contributor-tab" style="overflow: hidden; white-space: nowrap; width: 100%; padding: 8px 0; background-color: #f5f5f5; border-radius: 6px;">
+  <div id="contributor-list" style="display: inline-block; animation: scroll 15s linear infinite;">
     <!-- Contributor items (original list) -->
-    <div style="display: inline-block; padding: 10px; text-align: center; min-width: 150px;">
+    <div style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
       <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 5px;">
-        <div style="font-size: 14px; font-weight: bold;">Varunshiyam</div>
-        <div style="font-size: 12px; color: #666;">31 contributions</div>
+        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
+        <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
+        <div style="font-size: 11px; color: #555;">31 contributions</div>
       </a>
     </div>
-    <div style="display: inline-block; padding: 10px; text-align: center; min-width: 150px;">
+    <div style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
       <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 5px;">
-        <div style="font-size: 14px; font-weight: bold;">Meghana-2124</div>
-        <div style="font-size: 12px; color: #666;">1 contribution</div>
+        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
+        <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
+        <div style="font-size: 11px; color: #555;">1 contribution</div>
       </a>
     </div>
     <!-- Duplicated list for seamless infinite scroll -->
-    <div style="display: inline-block; padding: 10px; text-align: center; min-width: 150px;">
+    <div style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
       <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 5px;">
-        <div style="font-size: 14px; font-weight: bold;">Varunshiyam</div>
-        <div style="font-size: 12px; color: #666;">31 contributions</div>
+        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
+        <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
+        <div style="font-size: 11px; color: #555;">31 contributions</div>
       </a>
     </div>
-    <div style="display: inline-block; padding: 10px; text-align: center; min-width: 150px;">
+    <div style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
       <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 5px;">
-        <div style="font-size: 14px; font-weight: bold;">Meghana-2124</div>
-        <div style="font-size: 12px; color: #666;">1 contribution</div>
+        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
+        <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
+        <div style="font-size: 11px; color: #555;">1 contribution</div>
       </a>
     </div>
   </div>
@@ -230,24 +230,25 @@ Below is an auto-scrolling tab showcasing our amazing contributors and their con
   100% { transform: translateX(-50%); }
 }
 
-#contributor-tab::-webkit-scrollbar {
-  display: none; /* Hide scrollbar for cleaner look */
+#contributor-tab {
+  overflow-x: hidden;
 }
 
 #contributor-list:hover {
-  animation-play-state: paused; /* Pause on hover */
+  animation-play-state: paused;
 }
 
 @media (max-width: 600px) {
   #contributor-list div {
-    min-width: 120px; /* Smaller for mobile */
+    min-width: 110px;
+    padding: 6px;
   }
   #contributor-list img {
-    width: 40px;
-    height: 40px;
+    width: 30px;
+    height: 30px;
   }
   #contributor-list div div {
-    font-size: 12px; /* Adjust font */
+    font-size: 10px;
   }
 }
 </style>

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 
 
+
 ---
 
 ### Key Directories
@@ -188,66 +189,36 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 ## Contributors
 
-Below is an auto-scrolling tab showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
+Below is a tab showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
 
-<div id="contributor-tab" style="overflow: hidden; white-space: nowrap; width: 100%; padding: 8px 0; background-color: #f5f5f5; border-radius: 6px; display: inline-block;">
-  <div id="contributor-list" style="display: inline-block; animation: scroll 15s linear infinite;">
-    <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
-      <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
-        <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
-        <div style="font-size: 11px; color: #555;">31 contributions</div>
-      </a>
-    </span>
-    <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
-      <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
-        <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
-        <div style="font-size: 11px; color: #555;">1 contribution</div>
-      </a>
-    </span>
-    <!-- Duplicated for seamless scrolling -->
-    <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
-      <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
-        <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
-        <div style="font-size: 11px; color: #555;">31 contributions</div>
-      </a>
-    </span>
-    <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
-      <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
-        <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
-        <div style="font-size: 11px; color: #555;">1 contribution</div>
-      </a>
-    </span>
-  </div>
+<div style="overflow-x: auto; white-space: nowrap; width: 100%; padding: 8px 0; background-color: #f5f5f5; border-radius: 6px;">
+  <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+    <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
+      <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
+      <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
+      <div style="font-size: 11px; color: #555;">31 contributions</div>
+    </a>
+  </span>
+  <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+    <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
+      <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
+      <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
+      <div style="font-size: 11px; color: #555;">1 contribution</div>
+    </a>
+  </span>
 </div>
 
 <style>
-@keyframes scroll {
-  0% { margin-left: 0; }
-  100% { margin-left: -50%; }
-}
-
-#contributor-tab {
-  overflow: hidden;
-}
-
-#contributor-list:hover {
-  animation-play-state: paused;
-}
-
 @media (max-width: 600px) {
-  #contributor-list span {
+  span {
     min-width: 110px;
     padding: 6px;
   }
-  #contributor-list img {
+  img {
     width: 30px;
     height: 30px;
   }
-  #contributor-list div {
+  div {
     font-size: 10px;
   }
 }

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 
 
+
 ---
 
 ### Key Directories

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 
 
+
 ---
 
 ### Key Directories
@@ -192,26 +193,28 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 Below is a tab showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
 
-<div style="overflow-x: auto; white-space: nowrap; width: 100%; padding: 8px 0; background-color: #f5f5f5; border-radius: 6px;">
-  <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
-    <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
-      <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
-      <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
-      <div style="font-size: 11px; color: #555;">31 contributions</div>
-    </a>
-  </span>
-  <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
-    <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
-      <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
-      <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
-      <div style="font-size: 11px; color: #555;">1 contribution</div>
-    </a>
-  </span>
-</div>
+<table style="overflow-x: auto; white-space: nowrap; width: 100%; padding: 8px 0; background-color: #f5f5f5; border-radius: 6px; border-collapse: collapse;">
+  <tr>
+    <td style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+      <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
+        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
+        <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
+        <div style="font-size: 11px; color: #555;">31 contributions</div>
+      </a>
+    </td>
+    <td style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+      <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
+        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
+        <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
+        <div style="font-size: 11px; color: #555;">1 contribution</div>
+      </a>
+    </td>
+  </tr>
+</table>
 
 <style>
 @media (max-width: 600px) {
-  span {
+  td {
     min-width: 110px;
     padding: 6px;
   }

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 
 
+
 ---
 
 ### Key Directories
@@ -193,7 +194,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 ## Contributors
 
-Below is a tab showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
+These are our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
 
 <table style="overflow-x: auto; white-space: nowrap; width: 100%; padding: 12px 0; background: linear-gradient(to right, #f5f7fa, #e0e7ff); border-radius: 10px; border: 1px solid #d1d9e6; box-shadow: 0 2px 4px rgba(0,0,0,0.1); border-collapse: collapse; margin: 10px 0;">
   <tr>

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 
 
+
 ---
 
 ### Key Directories
@@ -195,38 +196,22 @@ Below is a tab showcasing our amazing contributors and their contribution counts
 
 <table style="overflow-x: auto; white-space: nowrap; width: 100%; padding: 8px 0; background-color: #f5f5f5; border-radius: 6px; border-collapse: collapse;">
   <tr>
-    <td style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+    <td style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle; @media (max-width: 600px) { min-width: 110px; padding: 6px; }">
       <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
-        <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
-        <div style="font-size: 11px; color: #555;">31 contributions</div>
+        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px; @media (max-width: 600px) { width: 30px; height: 30px; }">
+        <div style="font-size: 13px; font-weight: bold; @media (max-width: 600px) { font-size: 10px; }">Varunshiyam</div>
+        <div style="font-size: 11px; color: #555; @media (max-width: 600px) { font-size: 10px; }">31 contributions</div>
       </a>
     </td>
-    <td style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+    <td style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle; @media (max-width: 600px) { min-width: 110px; padding: 6px; }">
       <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
-        <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
-        <div style="font-size: 11px; color: #555;">1 contribution</div>
+        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px; @media (max-width: 600px) { width: 30px; height: 30px; }">
+        <div style="font-size: 13px; font-weight: bold; @media (max-width: 600px) { font-size: 10px; }">Meghana-2124</div>
+        <div style="font-size: 11px; color: #555; @media (max-width: 600px) { font-size: 10px; }">1 contribution</div>
       </a>
     </td>
   </tr>
 </table>
-
-<style>
-@media (max-width: 600px) {
-  td {
-    min-width: 110px;
-    padding: 6px;
-  }
-  img {
-    width: 30px;
-    height: 30px;
-  }
-  div {
-    font-size: 10px;
-  }
-}
-</style>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
-
 ![product-portfolio-salesai-background-2](https://github.com/user-attachments/assets/87a558bd-c9e7-43e3-b82f-b38f9f3145cc)
 
 # Internship Tracker & Skills Badge Manager APP
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/Varunshiyam/CRM-Driven-Internship-Application-Tracker/pulls)
-[![GitHub contributors](https://img.shields.io/github/contributors/Varunshiyam/internship-tracker)](https://github.com/Varunshiyam/CRM-Driven-Internship-Application-Tracker/graphs/contributors)
+[![GitHub contributors](https://img.shields.io/github/contributors/Varunshiyam/CRM-Driven-Internship-Application-Tracker)](https://github.com/Varunshiyam/CRM-Driven-Internship-Application-Tracker/graphs/contributors)
 [![License: GPL v2](https://img.shields.io/badge/License-GPLv2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
-[![GitHub issues](https://img.shields.io/github/issues/Varunshiyam/internship-tracker)](https://github.com/Varunshiyam/CRM-Driven-Internship-Application-Tracker/issues)
+[![GitHub issues](https://img.shields.io/github/issues/Varunshiyam/CRM-Driven-Internship-Application-Tracker)](https://github.com/Varunshiyam/CRM-Driven-Internship-Application-Tracker/issues)
 [![Discussions](https://img.shields.io/badge/Discussions-open-blue)](https://github.com/Varunshiyam/CRM-Driven-Internship-Application-Tracker/discussions)
 
 ---
-
-
 
 ## 📌 Project Overview
 
@@ -25,37 +22,25 @@ Built with **Lightning Web Components (LWC)** for a modern UI and comprehensive 
 - Earn badges recognizing skill achievements.
 - Automate important email notifications triggered by system events.
 
-This repository contains well-structured folders housing Apex classes, triggers, LWCs, object metadata, static resources, and essential docs.
+This repository contains well-structured folders housing Apex classes, triggers, LWCs, object metadata, and essential docs.
 
 ---
 
 ## Application Filter:
 
-
-
 https://github.com/user-attachments/assets/8c0468c0-8257-4881-8ffa-9c3a2279ec35
-
 
 ---
 
 ## Drag & Drop Skills:
 
-
-
-
 https://github.com/user-attachments/assets/d205771d-585b-4cd5-bd48-8362add3f666
-
 
 ---
 
 ## Achievements And Awards:
 
-
-
 https://github.com/user-attachments/assets/9428af47-f068-49fe-bd49-97d9f2d05425
-
-
-
 
 ---
 
@@ -66,6 +51,7 @@ https://github.com/user-attachments/assets/9428af47-f068-49fe-bd49-97d9f2d05425
 - [Automation & Logic](#-automation--logic)
 - [Lightning Web Components (LWC)](#-lightning-web-components-lwc)
 - [📂 Project Structure](#-project-structure)
+- [Contributors](#-contributors)
 - [Getting Started](#-getting-started)
 - [Contributing](#-contributing)
 - [License](#-license)
@@ -86,19 +72,11 @@ https://github.com/user-attachments/assets/9428af47-f068-49fe-bd49-97d9f2d05425
 
 ## Application Form:
 
-
-
-https://github.com/user-attachments/assets/772c1498-1106-4eaf-9e84-5c8a1299c3fe     
-
-
+https://github.com/user-attachments/assets/772c1498-1106-4eaf-9e84-5c8a1299c3fe
 
 https://github.com/user-attachments/assets/3ec68168-6526-4fd6-8e1e-d80bc5ba3234
 
-
-
-
 ---
-
 
 ## 🗂️ Data Models
 
@@ -154,6 +132,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 ## 📂 Project Structure
 
+
 ```
 .
 ├── .gitignore
@@ -192,6 +171,8 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
         └── SkillTrigger.trigger
 ```
 
+
+
 ---
 
 ### Key Directories
@@ -202,10 +183,74 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 * `lwc/`: Source code for the Lightning Web Components that make up the user interface.
 * `staticresources/`: Holds static assets like images, icons, and stylesheets.
 
-
-
 ---
 
+## Contributors
+
+Below is an auto-scrolling tab showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
+
+<div id="contributor-tab" style="overflow-x: hidden; white-space: nowrap; width: 100%; padding: 10px 0; background-color: #f9f9f9; border-radius: 8px;">
+  <div id="contributor-list" style="display: inline-block; animation: scroll 20s linear infinite;">
+    <!-- Contributor items (original list) -->
+    <div style="display: inline-block; padding: 10px; text-align: center; min-width: 150px;">
+      <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
+        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 5px;">
+        <div style="font-size: 14px; font-weight: bold;">Varunshiyam</div>
+        <div style="font-size: 12px; color: #666;">31 contributions</div>
+      </a>
+    </div>
+    <div style="display: inline-block; padding: 10px; text-align: center; min-width: 150px;">
+      <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
+        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 5px;">
+        <div style="font-size: 14px; font-weight: bold;">Meghana-2124</div>
+        <div style="font-size: 12px; color: #666;">1 contribution</div>
+      </a>
+    </div>
+    <!-- Duplicated list for seamless infinite scroll -->
+    <div style="display: inline-block; padding: 10px; text-align: center; min-width: 150px;">
+      <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
+        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 5px;">
+        <div style="font-size: 14px; font-weight: bold;">Varunshiyam</div>
+        <div style="font-size: 12px; color: #666;">31 contributions</div>
+      </a>
+    </div>
+    <div style="display: inline-block; padding: 10px; text-align: center; min-width: 150px;">
+      <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
+        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 5px;">
+        <div style="font-size: 14px; font-weight: bold;">Meghana-2124</div>
+        <div style="font-size: 12px; color: #666;">1 contribution</div>
+      </a>
+    </div>
+  </div>
+</div>
+
+<style>
+@keyframes scroll {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+#contributor-tab::-webkit-scrollbar {
+  display: none; /* Hide scrollbar for cleaner look */
+}
+
+#contributor-list:hover {
+  animation-play-state: paused; /* Pause on hover */
+}
+
+@media (max-width: 600px) {
+  #contributor-list div {
+    min-width: 120px; /* Smaller for mobile */
+  }
+  #contributor-list img {
+    width: 40px;
+    height: 40px;
+  }
+  #contributor-list div div {
+    font-size: 12px; /* Adjust font */
+  }
+}
+</style>
 
 ---
 
@@ -224,4 +269,14 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 We're Happy TO Welcome Contributions!
 
+---
 
+## 📜 License
+
+This project is licensed under the [GNU General Public License v2.0](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).
+
+---
+
+## 📬 Contact
+
+For inquiries, suggestions, or feedback, please reach out via [GitHub Discussions](https://github.com/Varunshiyam/CRM-Driven-Internship-Application-Tracker/discussions) or open an issue.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 
 
+
 ---
 
 ### Key Directories
@@ -194,20 +195,20 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 Below is a tab showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
 
-<table style="overflow-x: auto; white-space: nowrap; width: 100%; padding: 8px 0; background-color: #f5f5f5; border-radius: 6px; border-collapse: collapse;">
+<table style="overflow-x: auto; white-space: nowrap; width: 100%; padding: 12px 0; background: linear-gradient(to right, #f5f7fa, #e0e7ff); border-radius: 10px; border: 1px solid #d1d9e6; box-shadow: 0 2px 4px rgba(0,0,0,0.1); border-collapse: collapse; margin: 10px 0;">
   <tr>
-    <td style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle; @media (max-width: 600px) { min-width: 110px; padding: 6px; }">
+    <td style="display: inline-block; padding: 12px; text-align: center; min-width: 160px; vertical-align: middle; @media (max-width: 600px) { min-width: 120px; padding: 8px; }">
       <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px; @media (max-width: 600px) { width: 30px; height: 30px; }">
-        <div style="font-size: 13px; font-weight: bold; @media (max-width: 600px) { font-size: 10px; }">Varunshiyam</div>
-        <div style="font-size: 11px; color: #555; @media (max-width: 600px) { font-size: 10px; }">31 contributions</div>
+        <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 6px; @media (max-width: 600px) { width: 40px; height: 40px; }">
+        <div style="font-size: 15px; font-weight: bold; color: #2c3e50; @media (max-width: 600px) { font-size: 12px; }">Varunshiyam</div>
+        <div style="font-size: 13px; color: #7f8c8d; @media (max-width: 600px) { font-size: 10px; }">31 contributions</div>
       </a>
     </td>
-    <td style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle; @media (max-width: 600px) { min-width: 110px; padding: 6px; }">
+    <td style="display: inline-block; padding: 12px; text-align: center; min-width: 160px; vertical-align: middle; @media (max-width: 600px) { min-width: 120px; padding: 8px; }">
       <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
-        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px; @media (max-width: 600px) { width: 30px; height: 30px; }">
-        <div style="font-size: 13px; font-weight: bold; @media (max-width: 600px) { font-size: 10px; }">Meghana-2124</div>
-        <div style="font-size: 11px; color: #555; @media (max-width: 600px) { font-size: 10px; }">1 contribution</div>
+        <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 50px; height: 50px; border-radius: 50%; margin-bottom: 6px; @media (max-width: 600px) { width: 40px; height: 40px; }">
+        <div style="font-size: 15px; font-weight: bold; color: #2c3e50; @media (max-width: 600px) { font-size: 12px; }">Meghana-2124</div>
+        <div style="font-size: 13px; color: #7f8c8d; @media (max-width: 600px) { font-size: 10px; }">1 contribution</div>
       </a>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 
 
+
 ---
 
 ### Key Directories
@@ -189,49 +190,48 @@ These LWCs deliver a seamless, responsive user experience fully integrated with 
 
 Below is an auto-scrolling tab showcasing our amazing contributors and their contribution counts. (Auto-updated via GitHub Actions)
 
-<div id="contributor-tab" style="overflow: hidden; white-space: nowrap; width: 100%; padding: 8px 0; background-color: #f5f5f5; border-radius: 6px;">
+<div id="contributor-tab" style="overflow: hidden; white-space: nowrap; width: 100%; padding: 8px 0; background-color: #f5f5f5; border-radius: 6px; display: inline-block;">
   <div id="contributor-list" style="display: inline-block; animation: scroll 15s linear infinite;">
-    <!-- Contributor items (original list) -->
-    <div style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+    <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
       <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
         <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
         <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
         <div style="font-size: 11px; color: #555;">31 contributions</div>
       </a>
-    </div>
-    <div style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+    </span>
+    <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
       <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
         <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
         <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
         <div style="font-size: 11px; color: #555;">1 contribution</div>
       </a>
-    </div>
-    <!-- Duplicated list for seamless infinite scroll -->
-    <div style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+    </span>
+    <!-- Duplicated for seamless scrolling -->
+    <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
       <a href="https://github.com/Varunshiyam" target="_blank" style="text-decoration: none; color: #333;">
         <img src="https://avatars.githubusercontent.com/u/138989960?v=4" alt="Varunshiyam" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
         <div style="font-size: 13px; font-weight: bold;">Varunshiyam</div>
         <div style="font-size: 11px; color: #555;">31 contributions</div>
       </a>
-    </div>
-    <div style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
+    </span>
+    <span style="display: inline-block; padding: 8px; text-align: center; min-width: 140px; vertical-align: middle;">
       <a href="https://github.com/Meghana-2124" target="_blank" style="text-decoration: none; color: #333;">
         <img src="https://avatars.githubusercontent.com/u/204466699?v=4" alt="Meghana-2124" style="width: 40px; height: 40px; border-radius: 50%; margin-bottom: 4px;">
         <div style="font-size: 13px; font-weight: bold;">Meghana-2124</div>
         <div style="font-size: 11px; color: #555;">1 contribution</div>
       </a>
-    </div>
+    </span>
   </div>
 </div>
 
 <style>
 @keyframes scroll {
-  0% { transform: translateX(0); }
-  100% { transform: translateX(-50%); }
+  0% { margin-left: 0; }
+  100% { margin-left: -50%; }
 }
 
 #contributor-tab {
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 #contributor-list:hover {
@@ -239,7 +239,7 @@ Below is an auto-scrolling tab showcasing our amazing contributors and their con
 }
 
 @media (max-width: 600px) {
-  #contributor-list div {
+  #contributor-list span {
     min-width: 110px;
     padding: 6px;
   }
@@ -247,7 +247,7 @@ Below is an auto-scrolling tab showcasing our amazing contributors and their con
     width: 30px;
     height: 30px;
   }
-  #contributor-list div div {
+  #contributor-list div {
     font-size: 10px;
   }
 }


### PR DESCRIPTION
Added a rolling horizontal contributors tab to README.md, displaying contributor names and contribution counts. The tab is auto-updated via a GitHub Actions workflow that fetches data from the GitHub API. The design is clean, minimal, auto-scrolling, and responsive for desktop and mobile views. Includes hover pause and hidden scrollbar for readability.

Fixes #9 